### PR TITLE
Fix: build to avoid plugins folder being nuked.

### DIFF
--- a/2-java-plugin.sh
+++ b/2-java-plugin.sh
@@ -24,6 +24,7 @@ pe "find . -name *.zip"
 
 comment "Install the plugin into OpenSearch:"
 pe "cd ../OpenSearch"
+pe "./gradlew localDistro"
 pe "./distribution/archives/darwin-arm64-tar/build/install/opensearch-3.0.0-SNAPSHOT/bin/opensearch-plugin install file:///$ROOT/opensearch-hello-plugin-java/build/distributions/hello.zip"
 
 wait


### PR DESCRIPTION
Because for the search pipeline demo we modify code `./gradlew run` will rebuild and nuke `plugins` folder. So we need to build OpenSearch first.